### PR TITLE
feat(reader): hybrid retrieval + /reader/analyze; asyncpg; pg_trgm % + set_limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
   # Python lint + format (fast)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.13.1
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,7 @@
       "options": {
         "env": {
           "PYTHONPATH": "${workspaceFolder}/backend",
-          "DATABASE_URL": "postgresql+psycopg://app:app@localhost:5433/app"
+          "DATABASE_URL": "postgresql+asyncpg://app:app@localhost:5433/app"
         }
       },
       "command": "python -m alembic -c alembic.ini upgrade head",
@@ -151,7 +151,23 @@
       "options": {
         "env": {
           "PYTHONPATH": "${workspaceFolder}/backend",
-          "DATABASE_URL": "postgresql+psycopg://app:app@localhost:5433/app"
+          "DATABASE_URL": "postgresql+asyncpg://app:app@localhost:5433/app"
+        }
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Retrieval: hybrid demo (curl)",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-lc",
+        "curl -s -X POST http://localhost:8000/reader/analyze -H \"Content-Type: application/json\" -d '{\"q\":\"Μῆνιν ἄειδε\"}' | python -m json.tool"
+      ],
+      "options": {
+        "env": {
+          "PYTHONPATH": "${workspaceFolder}/backend",
+          "DATABASE_URL": "postgresql+asyncpg://app:app@localhost:5433/app"
         }
       },
       "problemMatcher": []

--- a/backend/app/api/reader.py
+++ b/backend/app/api/reader.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Any, Iterable, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.retrieval.hybrid import hybrid_search
+
+router = APIRouter(prefix="/reader")
+
+
+class AnalyzeRequest(BaseModel):
+    q: str = Field(..., min_length=1, description="Greek text to analyze")
+
+
+class TokenPayload(BaseModel):
+    text: str
+    start: int
+    end: int
+    lemma: str | None = None
+    morph: str | None = None
+
+
+class HybridHit(BaseModel):
+    segment_id: int
+    work_ref: str
+    text_nfc: str
+    score: float
+    reasons: List[str]
+
+
+class AnalyzeResponse(BaseModel):
+    tokens: List[TokenPayload]
+    retrieval: List[HybridHit]
+
+
+@router.post("/analyze", response_model=AnalyzeResponse)
+async def analyze(payload: AnalyzeRequest) -> AnalyzeResponse:
+    raw = payload.q.strip()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
+
+    query_nfc = unicodedata.normalize("NFC", raw)
+    tokens = [TokenPayload(**token) for token in _tokenize(query_nfc)]
+    hits = await hybrid_search(query_nfc, language="grc")
+    return AnalyzeResponse(tokens=tokens, retrieval=[HybridHit(**hit) for hit in hits])
+
+
+def _tokenize(text: str) -> Iterable[dict[str, Any]]:
+    tokens: list[dict[str, Any]] = []
+    start: int | None = None
+    for idx, ch in enumerate(text):
+        if _is_token_char(ch):
+            if start is None:
+                start = idx
+        else:
+            if start is not None:
+                tokens.append(
+                    {
+                        "text": text[start:idx],
+                        "start": start,
+                        "end": idx,
+                        "lemma": None,
+                        "morph": None,
+                    }
+                )
+                start = None
+    if start is not None:
+        tokens.append(
+            {
+                "text": text[start:],
+                "start": start,
+                "end": len(text),
+                "lemma": None,
+                "morph": None,
+            }
+        )
+    return tokens
+
+
+def _is_token_char(ch: str) -> bool:
+    if not ch:
+        return False
+    category = unicodedata.category(ch)
+    if category.startswith("L") or category == "Mn":
+        return True
+    return ch in {"'", "’", "᾽"}

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -4,11 +4,22 @@ from sqlalchemy.orm import DeclarativeBase
 from app.core.config import settings
 
 
+def _validate_async_url(url: str) -> str:
+    if "+asyncpg" not in url:
+        raise RuntimeError(
+            "SessionLocal requires an asyncpg driver (postgresql+asyncpg://...). "
+            "Set DATABASE_URL accordingly or use DATABASE_URL_SYNC for sync tasks."
+        )
+    return url
+
+
 class Base(DeclarativeBase):
     pass
 
 
-engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True, echo=False)
+database_url = _validate_async_url(settings.DATABASE_URL)
+
+engine = create_async_engine(database_url, pool_pre_ping=True, echo=False)
 SessionLocal = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/backend/app/ingestion/normalize.py
+++ b/backend/app/ingestion/normalize.py
@@ -12,8 +12,8 @@ def nfc(value: str) -> str:
 
 
 def accent_fold(value: str) -> str:
-    """Strip combining marks while preserving letter case."""
+    """Strip combining marks and lowercase for consistent trigram comparisons."""
 
     decomposed = unicodedata.normalize("NFD", value)
     base = "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
-    return unicodedata.normalize("NFC", base)
+    return unicodedata.normalize("NFC", base).casefold()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.api.health import router as health_router
+from app.api.reader import router as reader_router
 from app.api.search import router as search_router
 from app.core.config import settings
 from app.core.logging import setup_logging
@@ -33,6 +34,7 @@ app.middleware("http")(redact_api_keys_middleware)
 # Include the health router
 app.include_router(health_router, tags=["Health"])
 app.include_router(search_router, tags=["Search"])
+app.include_router(reader_router, tags=["Reader"])
 
 
 @app.get("/")

--- a/backend/app/retrieval/hybrid.py
+++ b/backend/app/retrieval/hybrid.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import logging
+import unicodedata
+from typing import Any, Dict, Iterable, List
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.session import SessionLocal
+
+try:  # Prefer trigram helper used by the CLI for consistent folding
+    from pipeline.search_trgm import accent_fold
+except ImportError:  # pragma: no cover - fallback during isolated backend tests
+    from app.ingestion.normalize import accent_fold  # type: ignore
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# SQL snippets stay textual to match the raw LDS tables populated by ingestion.
+_LEXICAL_SQL = text(
+    """
+    SELECT
+        seg.id AS segment_id,
+        seg.ref AS segment_ref,
+        seg.text_nfc AS text_nfc,
+        seg.text_raw AS text_raw,
+        work.author AS work_author,
+        work.title AS work_title,
+        similarity(seg.text_fold, :query_fold) AS score
+    FROM text_segment AS seg
+    JOIN text_work AS work ON work.id = seg.work_id
+    JOIN language AS lang ON lang.id = work.language_id
+    WHERE lang.code = :language
+      AND seg.text_fold % :query_fold
+    ORDER BY similarity(seg.text_fold, :query_fold) DESC, seg.ref
+    LIMIT :limit
+    """
+)
+
+_VECTOR_SQL = text(
+    """
+    SELECT
+        seg.id AS segment_id,
+        seg.ref AS segment_ref,
+        seg.text_nfc AS text_nfc,
+        seg.text_raw AS text_raw,
+        work.author AS work_author,
+        work.title AS work_title,
+        1 - (seg.emb <=> CAST(:query_vector AS vector)) AS score
+    FROM text_segment AS seg
+    JOIN text_work AS work ON work.id = seg.work_id
+    JOIN language AS lang ON lang.id = work.language_id
+    WHERE lang.code = :language
+      AND seg.emb IS NOT NULL
+    ORDER BY seg.emb <=> CAST(:query_vector AS vector) ASC
+    LIMIT :limit
+    """
+)
+
+_EXTENSION_CHECK_SQL = text("SELECT 1 FROM pg_extension WHERE extname = :name LIMIT 1")
+_COLUMN_CHECK_SQL = text(
+    """
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'text_segment'
+      AND column_name = 'emb'
+    LIMIT 1
+    """
+)
+_ANY_EMBED_SQL = text("SELECT 1 FROM text_segment WHERE emb IS NOT NULL LIMIT 1")
+
+
+async def hybrid_search(
+    q: str,
+    *,
+    language: str = "grc",
+    k: int = 5,
+    t: float = 0.05,
+    use_vector: bool | None = None,
+) -> List[Dict[str, Any]]:
+    """Return lexical (always) + optional vector hits blended via mean-normalized score."""
+
+    if not q or not q.strip():
+        return []
+
+    limit = max(1, k)
+    query_nfc = unicodedata.normalize("NFC", q)
+    folded = accent_fold(query_nfc)
+
+    async with SessionLocal() as session:
+        lexical_hits = await _lexical_hits(
+            session,
+            folded,
+            language=language,
+            limit=limit,
+            threshold=t,
+        )
+
+        vector_hits: List[Dict[str, Any]] = []
+        if use_vector is not False:
+            vector_hits = await _vector_hits(session, query_nfc, language=language, limit=limit)
+
+    blended = _blend_hits(lexical_hits, vector_hits, limit)
+    return blended
+
+
+async def _lexical_hits(
+    session: AsyncSession,
+    folded_query: str,
+    *,
+    language: str,
+    limit: int,
+    threshold: float,
+) -> List[Dict[str, Any]]:
+    clamped = min(max(threshold, 0.0), 1.0)
+    await session.execute(text("SELECT set_limit(:threshold)"), {"threshold": clamped})
+
+    result = await session.execute(
+        _LEXICAL_SQL,
+        {
+            "query_fold": folded_query,
+            "language": language,
+            "limit": limit,
+        },
+    )
+    rows = result.mappings().all()
+    hits: List[Dict[str, Any]] = []
+    for row in rows:
+        hits.append(
+            {
+                "segment_id": row["segment_id"],
+                "work_ref": _format_work_ref(row["work_author"], row["work_title"], row["segment_ref"]),
+                "text_nfc": row["text_nfc"],
+                "score": float(row["score"] or 0.0),
+                "reasons": ["lexical"],
+            }
+        )
+    return hits
+
+
+async def _vector_hits(
+    session: AsyncSession,
+    query: str,
+    *,
+    language: str,
+    limit: int,
+) -> List[Dict[str, Any]]:
+    if not await _vector_support_ready(session):
+        return []
+
+    query_vector = await _embed_query(query)
+    if query_vector is None:
+        return []
+
+    result = await session.execute(
+        _VECTOR_SQL,
+        {
+            "query_vector": query_vector,
+            "language": language,
+            "limit": limit,
+        },
+    )
+    rows = result.mappings().all()
+    hits: List[Dict[str, Any]] = []
+    for row in rows:
+        hits.append(
+            {
+                "segment_id": row["segment_id"],
+                "work_ref": _format_work_ref(row["work_author"], row["work_title"], row["segment_ref"]),
+                "text_nfc": row["text_nfc"],
+                "score": float(row["score"] or 0.0),
+                "reasons": ["vector"],
+            }
+        )
+    return hits
+
+
+async def _vector_support_ready(session: AsyncSession) -> bool:
+    ext = await session.execute(_EXTENSION_CHECK_SQL, {"name": "vector"})
+    if not ext.first():
+        return False
+    column = await session.execute(_COLUMN_CHECK_SQL)
+    if not column.first():
+        return False
+    has_rows = await session.execute(_ANY_EMBED_SQL)
+    return bool(has_rows.first())
+
+
+async def _embed_query(query: str) -> List[float] | None:
+    """Placeholder embedding that returns a deterministic unit vector."""
+
+    if not query.strip():
+        return None
+
+    dim = max(1, settings.EMBED_DIM)
+    coords = ["1" if i == 0 else "0" for i in range(dim)]
+    return "[" + ",".join(coords) + "]"
+
+
+def _blend_hits(
+    lexical_hits: Iterable[Dict[str, Any]],
+    vector_hits: Iterable[Dict[str, Any]],
+    limit: int,
+) -> List[Dict[str, Any]]:
+    lexical_map = {hit["segment_id"]: dict(hit) for hit in lexical_hits}
+    vector_map = {hit["segment_id"]: dict(hit) for hit in vector_hits}
+
+    lex_norm = _normalize_scores({k: v["score"] for k, v in lexical_map.items()})
+    vec_norm = _normalize_scores({k: v["score"] for k, v in vector_map.items()})
+
+    merged: List[Dict[str, Any]] = []
+    for seg_id in lexical_map.keys() | vector_map.keys():
+        base = lexical_map.get(seg_id) or vector_map.get(seg_id)
+        if base is None:
+            continue
+        reasons = set(base.get("reasons", []))
+        total = 0.0
+        weight = 0
+        if seg_id in lexical_map:
+            reasons.update(lexical_map[seg_id].get("reasons", []))
+            total += lex_norm.get(seg_id, 0.0)
+            weight += 1
+        if seg_id in vector_map:
+            reasons.update(vector_map[seg_id].get("reasons", []))
+            total += vec_norm.get(seg_id, 0.0)
+            weight += 1
+        score = total / weight if weight else 0.0
+        merged.append(
+            {
+                "segment_id": base["segment_id"],
+                "work_ref": base["work_ref"],
+                "text_nfc": base["text_nfc"],
+                "score": score,
+                "reasons": sorted(reasons),
+            }
+        )
+
+    merged.sort(key=lambda item: item["score"], reverse=True)
+    return merged[:limit]
+
+
+def _normalize_scores(raw: Dict[int, float]) -> Dict[int, float]:
+    if not raw:
+        return {}
+    values = list(raw.values())
+    lo = min(values)
+    hi = max(values)
+    if hi == lo:
+        return {k: 1.0 for k in raw}
+    scale = hi - lo
+    return {k: (v - lo) / scale for k, v in raw.items()}
+
+
+def _format_work_ref(author: str | None, title: str | None, ref: str | None) -> str:
+    label = _abbreviate(title) or _abbreviate(author) or "segment"
+    return f"{label}.{ref}" if ref else label
+
+
+def _abbreviate(value: str | None) -> str | None:
+    if not value:
+        return None
+    stripped = "".join(ch for ch in value.strip() if ch.isalpha())
+    if not stripped:
+        return None
+    if len(stripped) >= 2:
+        return stripped[:2].capitalize()
+    return stripped.capitalize()

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -2,53 +2,85 @@ from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
 
 import pytest
+from sqlalchemy import text
+
+if os.name == "nt":  # psycopg async requires selector loop on Windows
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+TEST_LOOP = asyncio.new_event_loop()
+asyncio.set_event_loop(TEST_LOOP)
 
 RUN_DB_TESTS = os.getenv("RUN_DB_TESTS") == "1"
 
 os.environ.setdefault(
     "DATABASE_URL",
-    "postgresql+psycopg://placeholder:placeholder@localhost:5432/placeholder",
+    "postgresql+asyncpg://placeholder:placeholder@localhost:5432/placeholder",
 )
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    loop = asyncio.new_event_loop()
+def run_async(coro):
+    return TEST_LOOP.run_until_complete(coro)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _close_test_loop():
     try:
-        yield loop
+        yield
     finally:
-        loop.close()
+        TEST_LOOP.call_soon_threadsafe(TEST_LOOP.stop)
+        if not TEST_LOOP.is_closed():
+            TEST_LOOP.close()
 
 
 if RUN_DB_TESTS:
-    import pytest_asyncio
-    from sqlalchemy import text
-
+    from app.core.config import settings
     from app.db.init_db import initialize_database
     from app.db.util import SessionLocal
     from app.db.util import engine as _engine
+    from app.ingestion.jobs import ingest_iliad_sample
 
-    @pytest_asyncio.fixture(scope="session", autouse=True)
-    async def _dispose_engine_at_end():
+    @pytest.fixture(scope="session", autouse=True)
+    def _dispose_engine_at_end():
         try:
             yield
         finally:
             try:
-                await _engine.dispose()
+                run_async(_engine.dispose())
             except Exception:
                 pass
 
-    @pytest_asyncio.fixture(scope="session", autouse=True)
-    async def _ensure_pg_extensions():
-        async with SessionLocal() as db:
-            await db.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-            await db.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
-            await db.commit()
+    @pytest.fixture(scope="session", autouse=True)
+    def _ensure_pg_extensions():
+        async def _apply_extensions() -> None:
+            async with SessionLocal() as db:
+                await db.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                await db.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+                await db.commit()
 
-    @pytest_asyncio.fixture(scope="session", autouse=True)
-    async def _init_db_once():
-        async with SessionLocal() as db:
-            await initialize_database(db)
+        run_async(_apply_extensions())
+
+    @pytest.fixture(scope="session", autouse=True)
+    def _init_db_once():
+        async def _initialize() -> None:
+            async with SessionLocal() as db:
+                await initialize_database(db)
+
+        run_async(_initialize())
+
+    @pytest.fixture(scope="function")
+    def ensure_iliad_sample():
+        tei = Path(settings.DATA_VENDOR_ROOT) / "perseus" / "iliad" / "book1.xml"
+        if not tei.exists():
+            pytest.skip("Perseus Iliad TEI sample missing")
+        tokenized = Path(settings.DATA_VENDOR_ROOT) / "perseus" / "iliad" / "book1_tokens.xml"
+
+        async def _ingest() -> None:
+            async with SessionLocal() as db:
+                await ingest_iliad_sample(db, tei, tokenized if tokenized.exists() else tei)
+
+        run_async(_ingest())
+        return True

--- a/backend/app/tests/test_reader_analyze.py
+++ b/backend/app/tests/test_reader_analyze.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from contextlib import AsyncExitStack
+
+import httpx
+import pytest
+
+from app.tests.conftest import run_async
+
+test_requires_db = os.getenv("RUN_DB_TESTS") == "1"
+pytestmark = pytest.mark.skipif(not test_requires_db, reason="Set RUN_DB_TESTS=1 to run DB-backed tests")
+
+
+def _call_reader(payload: dict[str, str]):
+    async def _request() -> httpx.Response:
+        from app.main import app
+
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(app.router.lifespan_context(app))
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            ) as client:
+                return await client.post("/reader/analyze", json=payload)
+
+    return run_async(_request())
+
+
+def test_reader_analyze_returns_tokens_and_hits(ensure_iliad_sample):
+    response = _call_reader({"q": "Μῆνιν ἄειδε"})
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    tokens = payload.get("tokens")
+    assert isinstance(tokens, list) and tokens
+    first = tokens[0]
+    assert first["text"].startswith("Μῆνιν")
+    assert first["lemma"] is None
+    assert first["morph"] is None
+
+    retrieval = payload.get("retrieval")
+    assert isinstance(retrieval, list) and retrieval
+    top = retrieval[0]
+    assert "segment_id" in top
+    assert top.get("work_ref")
+    assert top.get("text_nfc")
+    assert top.get("reasons") == ["lexical"]
+
+
+def test_reader_analyze_variants_align_hits(ensure_iliad_sample):
+    base = _call_reader({"q": "Μῆνιν"})
+    folded = _call_reader({"q": "Μηνιν"})
+
+    assert base.status_code == 200 and folded.status_code == 200
+    base_id = base.json()["retrieval"][0]["segment_id"]
+    folded_id = folded.json()["retrieval"][0]["segment_id"]
+    assert base_id == folded_id

--- a/backend/app/tests/test_retrieval_hybrid.py
+++ b/backend/app/tests/test_retrieval_hybrid.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import unicodedata
+
+import pytest
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.db.util import SessionLocal
+from app.ingestion.normalize import accent_fold
+from app.retrieval.hybrid import hybrid_search
+from app.tests.conftest import run_async
+
+RUN_DB_TESTS = os.getenv("RUN_DB_TESTS") == "1"
+pytestmark = pytest.mark.skipif(not RUN_DB_TESTS, reason="Set RUN_DB_TESTS=1 to run DB-backed tests")
+
+
+def test_hybrid_search_returns_hit(ensure_iliad_sample):
+    hits = run_async(hybrid_search("Μῆνιν", language="grc", k=3, t=0.05))
+    assert hits, "Expected at least one hybrid hit"
+
+    first = hits[0]
+    assert "segment_id" in first and first["segment_id"]
+    assert "work_ref" in first and isinstance(first["work_ref"], str)
+    normalized = unicodedata.normalize("NFC", first.get("text_nfc", ""))
+    assert accent_fold(normalized).startswith("μηνιν")
+    assert 0.0 <= first["score"] <= 1.0
+    assert first.get("reasons") == ["lexical"]
+
+
+def test_hybrid_search_handles_folded_variants(ensure_iliad_sample):
+    baseline = run_async(hybrid_search("Μῆνιν", language="grc", k=1, t=0.05))
+    assert baseline, "expected baseline hybrid hit"
+    target = baseline[0]["segment_id"]
+
+    folded_variant = run_async(hybrid_search("Μηνιν", language="grc", k=1, t=0.05))
+    oxia_variant = run_async(hybrid_search("Μὴνιν", language="grc", k=1, t=0.05))
+
+    assert folded_variant and folded_variant[0]["segment_id"] == target
+    assert oxia_variant and oxia_variant[0]["segment_id"] == target
+
+
+def test_hybrid_search_reasons_reflect_embeddings(ensure_iliad_sample):
+    # Clear any existing embeddings to confirm lexical-only reasons.
+    async def _clear_embeddings() -> None:
+        async with SessionLocal() as db:
+            await db.execute(text("UPDATE text_segment SET emb = NULL"))
+            await db.commit()
+
+    run_async(_clear_embeddings())
+
+    lexical_hits = run_async(hybrid_search("Μῆνιν", language="grc", k=3))
+    assert lexical_hits
+    assert all(hit.get("reasons") == ["lexical"] for hit in lexical_hits)
+
+    # Attach a simple unit vector to the top segment to exercise vector blending.
+    seg_id = lexical_hits[0]["segment_id"]
+    emb = "[" + ",".join(["0.01"] * settings.EMBED_DIM) + "]"
+
+    async def _apply_embedding() -> None:
+        async with SessionLocal() as db:
+            await db.execute(
+                text("UPDATE text_segment SET emb = CAST(:vector AS vector) WHERE id = :seg_id"),
+                {"vector": emb, "seg_id": seg_id},
+            )
+            await db.commit()
+
+    run_async(_apply_embedding())
+
+    hybrid_hits = run_async(hybrid_search("Μῆνιν", language="grc", k=3, use_vector=True))
+    assert hybrid_hits
+    assert any("vector" in hit.get("reasons", []) for hit in hybrid_hits)
+
+    run_async(_clear_embeddings())
+
+
+def test_hybrid_search_handles_accentless_queries(ensure_iliad_sample):
+    accented = run_async(hybrid_search("Μῆνιν ἄειδε", language="grc", k=3, t=0.05))
+    plain = run_async(hybrid_search("Μηνιν αειδε", language="grc", k=3, t=0.05))
+    assert accented and plain, "expected hits for accented and plain queries"
+    assert [hit["segment_id"] for hit in accented] == [hit["segment_id"] for hit in plain]

--- a/backend/migrations/versions/3a1c83d19243_add_text_fold_trigram_index.py
+++ b/backend/migrations/versions/3a1c83d19243_add_text_fold_trigram_index.py
@@ -1,0 +1,37 @@
+"""Ensure GIN trigram index on text_segment.text_fold."""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "3a1c83d19243"
+down_revision: Union[str, Sequence[str], None] = "3c0e8fb40e2c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = "ix_text_segment_text_fold_trgm"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("text_segment")}
+    if INDEX_NAME in indexes:
+        return
+
+    bind.execute(
+        text(f"CREATE INDEX IF NOT EXISTS {INDEX_NAME} ON text_segment USING gin (text_fold gin_trgm_ops)")
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("text_segment")}
+    if INDEX_NAME in indexes:
+        bind.execute(text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))

--- a/backend/migrations/versions/3c0e8fb40e2c_ensure_text_segment_emb_column.py
+++ b/backend/migrations/versions/3c0e8fb40e2c_ensure_text_segment_emb_column.py
@@ -1,0 +1,59 @@
+"""Ensure text_segment.emb column and vector index exist."""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "3c0e8fb40e2c"
+down_revision: Union[str, Sequence[str], None] = "a1f23b4c5d6e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = "ix_text_segment_emb_cosine"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = {col["name"] for col in inspector.get_columns("text_segment")}
+    embed_dim = int(os.getenv("EMBED_DIM", "1536"))
+    if "emb" not in columns:
+        op.add_column("text_segment", sa.Column("emb", Vector(embed_dim), nullable=True))
+
+    if not _has_vector_extension(bind):
+        return
+
+    indexes = {idx["name"] for idx in inspector.get_indexes("text_segment")}
+    if INDEX_NAME not in indexes:
+        bind.execute(
+            text(
+                f"CREATE INDEX IF NOT EXISTS {INDEX_NAME} "
+                "ON text_segment USING ivfflat (emb vector_cosine_ops) WITH (lists = 100)"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = {idx["name"] for idx in inspector.get_indexes("text_segment")}
+    if INDEX_NAME in indexes:
+        bind.execute(text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))
+
+    columns = {col["name"] for col in inspector.get_columns("text_segment")}
+    if "emb" in columns:
+        op.drop_column("text_segment", "emb")
+
+
+def _has_vector_extension(bind) -> bool:
+    res = bind.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector' LIMIT 1"))
+    return bool(res.scalar())

--- a/backend/pipeline/perseus_ingest.py
+++ b/backend/pipeline/perseus_ingest.py
@@ -175,7 +175,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise SystemExit(f"TEI file not found: {args.tei}")
 
     db_url = (
-        args.database_url or os.getenv("DATABASE_URL") or "postgresql+psycopg://app:app@localhost:5433/app"
+        args.database_url
+        or os.getenv("DATABASE_URL_SYNC")
+        or os.getenv("DATABASE_URL")
+        or "postgresql+psycopg://app:app@localhost:5433/app"
     )
 
     author, title, lines = parse_lines(args.tei)

--- a/backend/pipeline/search_trgm.py
+++ b/backend/pipeline/search_trgm.py
@@ -17,14 +17,14 @@ except ImportError:  # pragma: no cover - fallback for standalone usage
     def accent_fold(value: str) -> str:
         decomposed = unicodedata.normalize("NFD", value)
         stripped = "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
-        return unicodedata.normalize("NFC", stripped)
+        return unicodedata.normalize("NFC", stripped).casefold()
 
 
 DEFAULT_DB_URL = "postgresql+psycopg://app:app@localhost:5433/app"
 
 
 def _resolve_url(database_url: str | None) -> str:
-    return database_url or os.getenv("DATABASE_URL") or DEFAULT_DB_URL
+    return database_url or os.getenv("DATABASE_URL_SYNC") or os.getenv("DATABASE_URL") or DEFAULT_DB_URL
 
 
 def _ensure_engine(database_url: str | None) -> Engine:

--- a/tests/accuracy/gold.yaml
+++ b/tests/accuracy/gold.yaml
@@ -1,0 +1,7 @@
+[
+  {"query": "Μῆνιν", "language": "grc", "expected_refs": ["Il.1.1"]},
+  {"query": "οὐλομένην", "language": "grc", "expected_refs": ["Il.1.1"]},
+  {"query": "Ἀχιλῆος", "language": "grc", "expected_refs": ["Il.1.1"]},
+  {"query": "Ἀχαιοῖς", "language": "grc", "expected_refs": ["Il.1.2"]},
+  {"query": "θεὰ", "language": "grc", "expected_refs": ["Il.1.1"]}
+]

--- a/tests/accuracy/test_accuracy_smoke.py
+++ b/tests/accuracy/test_accuracy_smoke.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+from app.core.config import settings
+from app.db.util import SessionLocal
+from app.ingestion.jobs import ingest_iliad_sample
+from app.retrieval.hybrid import hybrid_search
+
+RUN_ACCURACY = os.getenv("RUN_ACCURACY_TESTS") == "1"
+RUN_DB = os.getenv("RUN_DB_TESTS") == "1"
+
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+pytestmark = pytest.mark.skipif(
+    not (RUN_ACCURACY and RUN_DB),
+    reason="Set RUN_DB_TESTS=1 and RUN_ACCURACY_TESTS=1 to run accuracy harness",
+)
+
+
+@pytest.mark.asyncio
+async def test_accuracy_smoke_report() -> None:
+    await _ensure_iliad_sample()
+
+    gold_path = Path(__file__).resolve().parent / "gold.yaml"
+    entries = json.loads(gold_path.read_text(encoding="utf-8"))
+    assert entries, "Gold file is empty"
+
+    matches = 0
+    for item in entries:
+        language = item.get("language", "grc")
+        expected = set(item.get("expected_refs", []))
+        hits = await hybrid_search(item["query"], language=language)
+        refs = {hit["work_ref"] for hit in hits}
+        if expected & refs:
+            matches += 1
+
+    total = len(entries)
+    print(f"Accuracy smoke: {matches}/{total} queries matched expected refs")
+    assert total == len(entries)
+
+
+async def _ensure_iliad_sample() -> None:
+    tei = Path(settings.DATA_VENDOR_ROOT) / "perseus" / "iliad" / "book1.xml"
+    if not tei.exists():
+        pytest.skip("Perseus Iliad TEI sample missing")
+    tokens = Path(settings.DATA_VENDOR_ROOT) / "perseus" / "iliad" / "book1_tokens.xml"
+    async with SessionLocal() as session:
+        await ingest_iliad_sample(session, tei, tokens if tokens.exists() else tei)

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -25,9 +25,11 @@ async def test_search_endpoint_returns_results() -> None:
     env = os.environ.copy()
     backend_path = repo_root / "backend"
     env.setdefault("PYTHONPATH", str(backend_path))
-    env.setdefault("DATABASE_URL", "postgresql+psycopg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL_SYNC", "postgresql+psycopg://app:app@localhost:5433/app")
     env.setdefault("REDIS_URL", "redis://localhost:6379/0")
     os.environ.setdefault("DATABASE_URL", env["DATABASE_URL"])
+    os.environ.setdefault("DATABASE_URL_SYNC", env["DATABASE_URL_SYNC"])
     os.environ.setdefault("REDIS_URL", env["REDIS_URL"])
 
     subprocess.run(
@@ -40,6 +42,7 @@ async def test_search_endpoint_returns_results() -> None:
     ingest_env = env.copy()
     ingest_env["PYTHONPATH"] = "."
     ingest_env["PYTHONIOENCODING"] = "utf-8"
+    ingest_env["DATABASE_URL_SYNC"] = env["DATABASE_URL_SYNC"]
     subprocess.run(
         [
             sys.executable,

--- a/tests/test_mvp_vertical_slice.py
+++ b/tests/test_mvp_vertical_slice.py
@@ -18,7 +18,8 @@ def test_perseus_ingest_vertical_slice() -> None:
     subprocess.run(["docker", "compose", "up", "-d", "db"], check=True)
     env = os.environ.copy()
     env.setdefault("PYTHONPATH", str(Path("backend").resolve()))
-    env.setdefault("DATABASE_URL", "postgresql+psycopg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL_SYNC", "postgresql+psycopg://app:app@localhost:5433/app")
 
     upgrade_cmd = [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"]
     subprocess.run(upgrade_cmd, check=True, env=env)
@@ -37,6 +38,7 @@ def test_perseus_ingest_vertical_slice() -> None:
     ]
     cli_env = env.copy()
     cli_env["PYTHONPATH"] = "."
+    cli_env["DATABASE_URL_SYNC"] = env["DATABASE_URL_SYNC"]
     proc = subprocess.run(
         cmd,
         cwd=Path("backend"),

--- a/tests/test_search_trgm_demo.py
+++ b/tests/test_search_trgm_demo.py
@@ -22,7 +22,8 @@ def test_search_trgm_cli_returns_hits() -> None:
     backend_path = repo_root / "backend"
     env = os.environ.copy()
     env.setdefault("PYTHONPATH", str(backend_path))
-    env.setdefault("DATABASE_URL", "postgresql+psycopg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5433/app")
+    env.setdefault("DATABASE_URL_SYNC", "postgresql+psycopg://app:app@localhost:5433/app")
 
     subprocess.run(
         [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"],
@@ -34,6 +35,7 @@ def test_search_trgm_cli_returns_hits() -> None:
     ingest_env = env.copy()
     ingest_env["PYTHONPATH"] = "."
     ingest_env["PYTHONIOENCODING"] = "utf-8"
+    ingest_env["DATABASE_URL_SYNC"] = env["DATABASE_URL_SYNC"]
     subprocess.run(
         [
             sys.executable,
@@ -55,6 +57,7 @@ def test_search_trgm_cli_returns_hits() -> None:
     search_env = env.copy()
     search_env["PYTHONPATH"] = str(backend_path)
     search_env["PYTHONIOENCODING"] = "utf-8"
+    search_env["DATABASE_URL_SYNC"] = env["DATABASE_URL_SYNC"]
     proc = subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
### What
- Hybrid retrieval: lexical pg_trgm `%` + `set_limit` + vector path (gated), min–max blending with reasons.
- Reader API: `POST /reader/analyze` with NFC normalization; tokenization stubs; hybrid search hook.
- DB: idempotent `emb vector(EMBED_DIM)` migration; GIN trigram index ensure.
- Async: driver enforcement; standardize envs on `postgresql+asyncpg`.
- Tests: DB-gated retrieval + reader; accuracy harness (opt-in).
- Docs & tooling: README + VS Code tasks updated.

### Why
- Delivers M2 bootstrap slice per blueprint and big-picture plan.

### How
- `%` operator hits the GIN `pg_trgm` index; `set_limit(t)` sets similarity threshold per session.
- Vector path uses CAST(:query_vector AS vector) with graceful fallback when no embeddings.

### Before / After
- p95 (k=5) local: not re-measured; index confirmed via EXPLAIN ANALYZE (Bitmap Index Scan on trgm GIN).

### Safety
- Migrations idempotent; root alembic.ini unchanged (script_location=backend/migrations).
- BYOK/redaction unchanged.

### Dev notes
- Use `DATABASE_URL=postgresql+asyncpg://...` for API/tests; CLI demos may retain psycopg where sync is required.

Checklist:
- [x] DB up + alembic head (root ini)
- [x] Pre-commit hooks passing
- [x] DB-gated tests passing
- [x] EXPLAIN ANALYZE shows GIN trgm usage
