### PR TITLE
perf: add latency bench tooling

### DIFF
--- a/.github/workflows/bench-latency.yml
+++ b/.github/workflows/bench-latency.yml
@@ -1,0 +1,164 @@
+name: bench-latency
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Timed request count (default 150)
+        required: false
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  bench:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-bench'))
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql+asyncpg://app:app@127.0.0.1:5433/app
+      DATABASE_URL_SYNC: postgresql+psycopg://app:app@127.0.0.1:5433/app
+      PYTHONPATH: backend
+      BENCH_RUNS: ${{ github.event.inputs.runs }}
+      REDIS_URL: redis://127.0.0.1:6379/0
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: app
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U app -d app"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Wait for database
+        run: |
+          python - <<'PY_WAIT'
+          import asyncio
+          import os
+          import time
+
+          import asyncpg
+
+          async def main() -> None:
+              url = os.getenv('DATABASE_URL_SYNC', 'postgresql+psycopg://app:app@127.0.0.1:5433/app')
+              url = url.replace('postgresql+psycopg://', 'postgresql://')
+              deadline = time.time() + 60
+              while time.time() < deadline:
+                  try:
+                      conn = await asyncpg.connect(url)
+                  except Exception:
+                      await asyncio.sleep(1)
+                  else:
+                      await conn.close()
+                      return
+              raise SystemExit('Database not ready after 60s')
+
+          asyncio.run(main())
+          PY_WAIT
+
+      - name: Apply migrations
+        run: |
+          DATABASE_URL="$DATABASE_URL_SYNC" \
+          python -m alembic -c alembic.ini upgrade head
+
+      - name: Run latency bench
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUNS="${BENCH_RUNS:-}"
+          if [ -z "$RUNS" ]; then
+            RUNS=150
+          fi
+          mkdir -p artifacts
+          uvicorn app.main:app --host 127.0.0.1 --port 8000 &
+          UVICORN_PID=$!
+          trap 'kill "${UVICORN_PID}" 2>/dev/null || true' EXIT
+          for attempt in {1..30}; do
+            if curl -sSf http://127.0.0.1:8000/health > /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          python scripts/dev/bench_reader.py \
+            --base-url http://127.0.0.1:8000 \
+            --runs "$RUNS" \
+            --warmup 30 \
+            --include '{"lsj": true, "smyth": true}' \
+            --payload '{"q": "μῆνιν ἄειδε"}' \
+            | tee artifacts/bench_output.txt
+
+      - name: Upload bench artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-latency
+          path: artifacts/bench_output.txt
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const outputPath = 'artifacts/bench_output.txt';
+            if (!fs.existsSync(outputPath)) {
+              core.warning('Bench output missing; skipping comment.');
+              return;
+            }
+            const marker = '<!-- bench-latency -->';
+            const output = fs.readFileSync(outputPath, 'utf8').trim();
+            const body = `${marker}\n### Latency Bench\n\n${output}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.user?.login === 'github-actions[bot]' && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ pre-commit run --all-files
 4. Perf sanity (dev):
 
    ```bash
-   python scripts/dev/bench_reader.py --runs 200 --warmup 50
+   python scripts/dev/bench_reader.py --runs 150 --warmup 30 --include '{"lsj": true, "smyth": true}'
    ```
 
-   Prints p50/p95 latency for `/reader/analyze` using HTTPX against the local Uvicorn server.
+   Prints p50/p95/p99/mean latency for `/reader/analyze`; see [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for options and the CI job.
 
 **Reset (destructive):**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,23 @@
+# Latency Benchmarks
+
+The reader latency bench uses the same FastAPI instance as local development.
+
+## Local workflow
+
+1. Bring up Postgres and apply migrations via the root `alembic.ini`.
+2. Start Uvicorn on `127.0.0.1:8000` (`PYTHONPATH=backend uvicorn app.main:app --reload`).
+3. Run the bench script with the desired sample size:
+   ```bash
+   python scripts/dev/bench_reader.py --runs 150 --warmup 30 --include '{"lsj": true, "smyth": true}' --payload '{"q": "μῆνιν ἄειδε"}'
+   ```
+
+`scripts/dev/bench_reader.py` prints a Markdown table (p50/p95/p99/mean in milliseconds) plus the run parameters. Adjust `--payload`, `--include`, or `--base-url` when exploring other cases; `--runs`/`--warmup` trade precision for duration.
+
+## GitHub Actions job
+
+`.github/workflows/bench-latency.yml` runs on:
+
+- `workflow_dispatch` (optional `runs` input, default 150)
+- Pull requests labeled `run-bench`
+
+The job provisions Postgres 16, applies migrations, launches Uvicorn, executes the bench (`--runs 150 --warmup 30` unless overridden), uploads `artifacts/bench_output.txt`, and posts/updates a single PR comment marked by `<!-- bench-latency -->`. The job is informational; use it to spot regressions without blocking merges.

--- a/scripts/dev/bench_reader.py
+++ b/scripts/dev/bench_reader.py
@@ -2,54 +2,111 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import statistics
 import time
-from typing import List
+from typing import Any, Dict, List
 
 import httpx
 
-DEFAULT_URL = "http://localhost:8000/reader/analyze"
-DEFAULT_QUERY = {"q": "μῆνιν ἄειδε"}
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+READER_PATH = "/reader/analyze"
+DEFAULT_PAYLOAD = {"q": "μῆνιν ἄειδε"}
 
 
-async def _bench(url: str, runs: int, warmup: int, payload: dict[str, str]) -> List[float]:
+def _parse_json(text: str, *, label: str) -> Dict[str, Any]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"Invalid {label} JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise argparse.ArgumentTypeError(f"{label} JSON must be an object")
+    return data
+
+
+def _percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = int(round((pct / 100.0) * (len(ordered) - 1)))
+    return ordered[index]
+
+
+async def _bench(
+    *,
+    base_url: str,
+    runs: int,
+    warmup: int,
+    payload: Dict[str, Any],
+    include: Dict[str, Any],
+    timeout: float,
+) -> List[float]:
+    params = {"include": json.dumps(include)} if include else None
     durations: List[float] = []
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout) as client:
         for _ in range(warmup):
-            response = await client.post(url, json=payload)
+            response = await client.post(READER_PATH, params=params, json=payload)
             response.raise_for_status()
         for _ in range(runs):
             start = time.perf_counter()
-            response = await client.post(url, json=payload)
+            response = await client.post(READER_PATH, params=params, json=payload)
             response.raise_for_status()
             durations.append((time.perf_counter() - start) * 1000.0)
     return durations
 
 
-def _percentile(samples: List[float], pct: float) -> float:
-    if not samples:
-        return 0.0
-    ordered = sorted(samples)
-    idx = int(round((pct / 100.0) * (len(ordered) - 1)))
-    return ordered[idx]
-
-
 async def main() -> None:
     parser = argparse.ArgumentParser(description="Benchmark /reader/analyze latency")
-    parser.add_argument("--url", default=DEFAULT_URL, help="Endpoint to benchmark")
-    parser.add_argument("--runs", type=int, default=200, help="Timed request count (default: 200)")
-    parser.add_argument("--warmup", type=int, default=50, help="Warmup request count (default: 50)")
-    parser.add_argument("--query", default=DEFAULT_QUERY["q"], help="Query string to send")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Server base URL")
+    parser.add_argument("--runs", type=int, default=150, help="Timed request count (default: 150)")
+    parser.add_argument("--warmup", type=int, default=30, help="Warmup request count (default: 30)")
+    parser.add_argument(
+        "--payload",
+        default=json.dumps(DEFAULT_PAYLOAD, ensure_ascii=False),
+        help="JSON payload for the request",
+    )
+    parser.add_argument(
+        "--include",
+        default="{}",
+        help='JSON object passed as include query string (e.g. {"lsj":true})',
+    )
+    parser.add_argument("--timeout", type=float, default=30.0, help="Request timeout in seconds")
     args = parser.parse_args()
 
-    durations = await _bench(args.url, args.runs, args.warmup, {"q": args.query})
-    p50 = statistics.median(durations) if durations else 0.0
-    p95 = _percentile(durations, 95.0)
-    avg = statistics.fmean(durations) if durations else 0.0
+    payload = _parse_json(args.payload, label="payload")
+    include = _parse_json(args.include, label="include") if args.include else {}
 
+    durations = await _bench(
+        base_url=args.base_url,
+        runs=args.runs,
+        warmup=args.warmup,
+        payload=payload,
+        include=include,
+        timeout=args.timeout,
+    )
+    p50 = _percentile(durations, 50.0)
+    p95 = _percentile(durations, 95.0)
+    p99 = _percentile(durations, 99.0)
+    mean = statistics.fmean(durations) if durations else 0.0
+
+    print("| Stat | Value (ms) |")
+    print("| --- | --- |")
+    print(f"| p50 | {p50:.1f} |")
+    print(f"| p95 | {p95:.1f} |")
+    print(f"| p99 | {p99:.1f} |")
+    print(f"| mean | {mean:.1f} |")
+    print()
+    params_repr = json.dumps(include, ensure_ascii=False)
+    payload_repr = json.dumps(payload, ensure_ascii=False)
     print(
-        f"Benchmark for {args.url} samples={len(durations)} warmup={args.warmup} "
-        f"p50={p50:.1f}ms p95={p95:.1f}ms avg={avg:.1f}ms"
+        "Runs={runs} Warmup={warmup} BaseURL={base_url}{path} Include={include} Payload={payload}".format(
+            runs=args.runs,
+            warmup=args.warmup,
+            base_url=args.base_url.rstrip("/"),
+            path=READER_PATH,
+            include=params_repr,
+            payload=payload_repr,
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- extend `scripts/dev/bench_reader.py` with JSON payload/include options plus p50/p95/p99 reporting
- add `.github/workflows/bench-latency.yml` to run on `run-bench` label or manual dispatch and post a single comment
- document the workflow in docs/BENCHMARKS.md and link it from the README

## Testing
- docker compose up -d db
- python -m alembic -c alembic.ini upgrade head
- python scripts/dev/bench_reader.py --runs 150 --warmup 30 --include `{"lsj": true, "smyth": true}`
- pytest -q
- pre-commit run --all-files

## Bench

| Stat | Value (ms) |
| --- | --- |
| p50 | 9.4 |
| p95 | 10.4 |
| p99 | 12.8 |
| mean | 9.6 |

Runs=150 Warmup=30 BaseURL=http://127.0.0.1:8000/reader/analyze Include={"lsj": true, "smyth": true} Payload={"q": "μῆνιν ἄειδε"}
