### PR TITLE
docs: add hosting quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ pytest -q
 pre-commit run --all-files
 ```
 
+See [docs/DEMO.md](docs/DEMO.md) for the full demo walkthrough and [docs/HOSTING.md](docs/HOSTING.md) for hosting flags (`SERVE_FLUTTER_WEB=1`, `ALLOW_DEV_CORS=1`) and `/app/` serving notes.
+
 ## Prerequisites
 
 * Conda (Miniconda/Miniforge) with Python 3.12

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -1,0 +1,37 @@
+# Hosting Notes
+
+Reader v0 ships with demo scripts that orchestrate the full stack locally: Dockerized Postgres, Alembic migrations (root `alembic.ini`), the FastAPI app, and the Flutter web bundle mounted under `/app/`. Keep the demo flags unchanged—`SERVE_FLUTTER_WEB=1` enables the static bundle and `ALLOW_DEV_CORS=1` relaxes CORS for local clients.
+
+## One-command demo
+
+Unix:
+
+```bash
+scripts/dev/run_demo.sh
+```
+
+Windows (PowerShell):
+
+```powershell
+scripts/dev/run_demo.ps1
+```
+
+Both scripts perform the following:
+
+1. `docker compose up -d db`
+2. `python -m alembic -c alembic.ini upgrade head`
+3. Build the Flutter web bundle and serve it at `/app/`
+4. Start Uvicorn with `SERVE_FLUTTER_WEB=1` and `ALLOW_DEV_CORS=1`
+
+When Uvicorn reports `127.0.0.1:8000`, navigate to `http://127.0.0.1:8000/app/` for the Flutter UI and use `/reader/analyze` for API checks. BYOK remains request-scoped; never persist user-provided keys.
+
+## Deploy quickstart (stub)
+
+For production you will need to provide your own process manager and HTTPS termination. Recommended next steps:
+
+- Provision Postgres 16 with the same extensions as the demo (see `docs/DEMO.md`).
+- Run migrations with `python -m alembic -c alembic.ini upgrade head` during deploys.
+- Configure FastAPI (e.g., uvicorn/gunicorn) to set `SERVE_FLUTTER_WEB=1` only when the static bundle should be exposed under `/app/`.
+- Keep `ALLOW_DEV_CORS` disabled unless a trusted frontend requires it.
+
+See [docs/DEMO.md](docs/DEMO.md) for the full demo flow and smoke tests.


### PR DESCRIPTION
## Summary
- add docs/HOSTING.md capturing the one-command demo, required flags (`SERVE_FLUTTER_WEB=1`, `ALLOW_DEV_CORS=1`), and `/app/` serving notes
- mention the doc from README so demo and hosting flags stay discoverable

## Testing
- pre-commit run --all-files
